### PR TITLE
Pass NODE_NAME through downward API, prefer to use for matching node

### DIFF
--- a/cmd/networking-agent/main.go
+++ b/cmd/networking-agent/main.go
@@ -89,7 +89,15 @@ func main() {
 	}
 
 	var matcher func(node *v1.Node) bool
-	if options.MachineIDPath != "" {
+	if nodeName := os.Getenv("NODE_NAME"); nodeName != "" {
+		// Passing NODE_NAME via downward API is preferred
+		glog.Infof("will match node on name=%q", nodeName)
+		matcher = func(node *v1.Node) bool {
+			return node.Name == nodeName
+		}
+	} else if options.MachineIDPath != "" {
+		glog.Warningf("using MachineIDPath is deprecated - prefer passing NODE_NAME via downward API")
+
 		b, err := ioutil.ReadFile(options.MachineIDPath)
 		if err != nil {
 			glog.Fatalf("error reading machine-id file %q: %v", options.MachineIDPath, err)
@@ -97,30 +105,46 @@ func main() {
 		machineID := string(b)
 		machineID = strings.TrimSpace(machineID)
 
+		glog.Infof("will match node on machineid=%q", machineID)
 		matcher = func(node *v1.Node) bool {
 			return node.Status.NodeInfo.MachineID == machineID
 		}
 	} else if options.SystemUUIDPath != "" {
+		glog.Warningf("using SystemUUIDPath is deprecated - prefer passing NODE_NAME via downward API")
+
 		b, err := ioutil.ReadFile(options.SystemUUIDPath)
 		if err != nil {
 			glog.Fatalf("error reading system-uuid file %q: %v", options.SystemUUIDPath, err)
 		}
 		systemUUID := string(b)
 		systemUUID = strings.TrimSpace(systemUUID)
+
+		// If the BIOS isn't correctly configured, we'll
+		if systemUUID == "03000200-0400-0500-0006-000700080009" {
+			glog.Fatalf("detected well-known invalid system-uuid 03000200-0400-0500-0006-000700080009")
+		}
+
+		glog.Infof("will match node on systemUUID=%q", systemUUID)
 		matcher = func(node *v1.Node) bool {
 			return node.Status.NodeInfo.SystemUUID == systemUUID
 		}
 	} else if options.BootIDPath != "" {
+		glog.Warningf("using BootIDPath is deprecated - prefer passing NODE_NAME via downward API")
+
 		b, err := ioutil.ReadFile(options.BootIDPath)
 		if err != nil {
 			glog.Fatalf("error reading boot-id file %q: %v", options.BootIDPath, err)
 		}
 		bootID := string(b)
 		bootID = strings.TrimSpace(bootID)
+
+		glog.Infof("will match node on bootID=%q", bootID)
 		matcher = func(node *v1.Node) bool {
 			return node.Status.NodeInfo.BootID == bootID
 		}
 	} else {
+		glog.Warningf("using NodeName is deprecated - prefer passing NODE_NAME via downward API")
+
 		matchNodeName := options.NodeName
 		if matchNodeName == "" {
 			hostname, err := os.Hostname()
@@ -130,6 +154,7 @@ func main() {
 			glog.Infof("Using hostname as node name: %q", hostname)
 			matchNodeName = hostname
 		}
+		glog.Infof("will match node on name=%q", matchNodeName)
 		matcher = func(node *v1.Node) bool {
 			return node.Name == matchNodeName
 		}

--- a/k8s/kopeio-networking.yaml
+++ b/k8s/kopeio-networking.yaml
@@ -34,6 +34,11 @@ spec:
             - name: lib-modules
               mountPath: /lib/modules
               readOnly: true
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
       serviceAccountName: kopeio-networking-agent
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/pkg/routing/nodes.go
+++ b/pkg/routing/nodes.go
@@ -103,6 +103,7 @@ func (m *NodeMap) updateNode(src *v1.Node) bool {
 
 	if m.me == nil {
 		if m.mePredicate(src) {
+			glog.Infof("identified self node: %q", src.Name)
 			m.me = node
 			changed = true
 		}


### PR DESCRIPTION
We found some physical hardware that had identical system uuids - we now
panic if we hit that uuid, and we use the NODE_NAME via the downward API
as our preferred method of node identification.