### PR TITLE
Discover primary NIC more reliably

### DIFF
--- a/cmd/networking-agent/options.go
+++ b/cmd/networking-agent/options.go
@@ -56,7 +56,7 @@ func (o *Options) InitDefaults() {
 	o.LogLevel = &logLevel
 
 	o.ResyncPeriod = 30 * time.Second
-	o.TargetLinkName = "eth0"
+	o.TargetLinkName = ""
 	o.Provider = "vxlan"
 
 	o.PodCIDR = "100.96.0.0/12"


### PR DESCRIPTION
Don't assume it is called eth0, rather look for ethernet interfaces.

If a system has more than one, it must now be specified.