### PR TITLE
Enable GRE

### DIFF
--- a/cmd/networking-agent/BUILD.bazel
+++ b/cmd/networking-agent/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//:go_default_library",
         "//pkg/routing:go_default_library",
+        "//pkg/routing/gre:go_default_library",
         "//pkg/routing/ipsec:go_default_library",
         "//pkg/routing/layer2:go_default_library",
         "//pkg/routing/vxlan:go_default_library",

--- a/cmd/networking-agent/main.go
+++ b/cmd/networking-agent/main.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/rest"
 	"kope.io/networking"
 	"kope.io/networking/pkg/routing"
+	"kope.io/networking/pkg/routing/gre"
 	"kope.io/networking/pkg/routing/ipsec"
 	"kope.io/networking/pkg/routing/layer2"
 	"kope.io/networking/pkg/routing/vxlan"
@@ -179,8 +180,7 @@ func main() {
 	case "layer2":
 		provider, err = layer2.NewLayer2RoutingProvider(targetLinkName)
 	case "gre":
-		glog.Fatalf("GRE temporarily not enabled - until patch goes upstream")
-	// provider, err = gre.NewGreRoutingProvider()
+		provider, err = gre.NewGreRoutingProvider()
 	case "vxlan-legacy":
 		_, overlayCIDR, _ := net.ParseCIDR(options.PodCIDR)
 		provider, err = vxlan.NewVxlanRoutingProvider(overlayCIDR, targetLinkName)


### PR DESCRIPTION
vxlan remains the primary recommended option, but we can support GRE.