### PR TITLE
bazel: pass --stamp=true

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --workspace_status_command=./tools/get_workspace_status.sh
+build --workspace_status_command=./tools/get_workspace_status.sh --stamp=true


### PR DESCRIPTION
This enables variables in x_defs, a breaking change in rules_go 0.19