### PR TITLE
image: entrypoint should just be command

### DIFF
--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -11,7 +11,7 @@ container_image(
     name = "networking-agent",
     base = "@debian-base-amd64//image",
     directory = "/",
-    entrypoint = "/networking-agent",
+    entrypoint = [ "/networking-agent" ], # Subtle!  Passing a raw string wraps with /bin/sh -c, which means that adding args doesn't work as you might expect
     files = [
         "//cmd/networking-agent",
     ],


### PR DESCRIPTION
We don't want the entrypoint to include the "/bin/sh -c" wrapper,
because that interacts badly with just specifying kubernetes args.