### PR TITLE
vxlan2: avoid route churn

### DIFF
--- a/pkg/routing/netutil/route_table.go
+++ b/pkg/routing/netutil/route_table.go
@@ -55,7 +55,7 @@ func (t *RouteTable) Ensure(link netlink.Link, expected []*netlink.Route, delete
 		}
 
 		if !routeEqual(a, e) {
-			klog.V(2).Infof("change for %s:\n\ta: %s\n\te: %s", k, util.AsJsonString(a), util.AsJsonString(e))
+			klog.Infof("change for %s:\n\ta: %s\n\te: %s", k, util.AsJsonString(a), util.AsJsonString(e))
 			remove = append(remove, a)
 			create = append(create, e)
 		}

--- a/pkg/routing/vxlan2/vxlan2routing.go
+++ b/pkg/routing/vxlan2/vxlan2routing.go
@@ -208,6 +208,9 @@ func (p *VxlanRoutingProvider) EnsureCIDRs(nodeMap *routing.NodeMap) error {
 			Scope:     netlink.SCOPE_UNIVERSE,
 			Dst:       remote.PodCIDR,
 			Gw:        remote.PodCIDR.IP,
+			Protocol:  syscall.RTPROT_BOOT,
+			Table:     syscall.RT_TABLE_MAIN,
+			Type:      syscall.RTN_UNICAST,
 		}
 		route.SetFlag(syscall.RTNH_F_ONLINK)
 		routes = append(routes, route)


### PR DESCRIPTION
We set additional options so that the comparison is equal to avoid
deleting & recreating routes unnecessarily.
