### PR TITLE
vxlan2: Avoid neighbour table churn

### DIFF
--- a/pkg/routing/netutil/neigh_table.go
+++ b/pkg/routing/netutil/neigh_table.go
@@ -64,7 +64,7 @@ func (t *NeighTable) Ensure(link netlink.Link, expected []*netlink.Neigh) error 
 		}
 
 		if !neighEqual(a, e) {
-			klog.V(2).Infof("neigh change for %s:\n\t%s\n\t%s", k, util.AsJsonString(a), util.AsJsonString(e))
+			klog.Infof("neigh change for %s:\n\t%s\n\t%s", k, util.AsJsonString(a), util.AsJsonString(e))
 			upsert = append(upsert, e)
 		}
 	}

--- a/pkg/routing/vxlan2/vxlan2routing.go
+++ b/pkg/routing/vxlan2/vxlan2routing.go
@@ -206,6 +206,7 @@ func (p *VxlanRoutingProvider) EnsureCIDRs(nodeMap *routing.NodeMap) error {
 
 		arp := &netlink.Neigh{
 			LinkIndex:    linkIndex,
+			Family:       netlink.FAMILY_V4,
 			State:        netlink.NUD_PERMANENT,
 			Type:         syscall.RTN_UNICAST,
 			IP:           remote.PodCIDR.IP,


### PR DESCRIPTION
Set the neighbour table more carefully to match the actual spec.
